### PR TITLE
added sorting for file paths

### DIFF
--- a/src/filesystem_utils.h
+++ b/src/filesystem_utils.h
@@ -4,15 +4,18 @@
 #include <stdio.h>
 #include <vector>
 #include <string>
+#include <algorithm>
 
 #if _WIN32
 #include <windows.h>
 #include "win32dirent.h"
 #else // _WIN32
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
+
 #endif // _WIN32
 
 #if _WIN32
@@ -51,32 +54,30 @@ static int list_directory(const path_t& dirpath, std::vector<path_t>& imagepaths
     }
 
     _wclosedir(dir);
+    std::sort(imagepaths.begin(), imagepaths.end());
 
     return 0;
 }
 #else // _WIN32
-static bool path_is_directory(const path_t& path)
-{
+
+static bool path_is_directory(const path_t &path) {
     struct stat s;
     if (stat(path.c_str(), &s) != 0)
         return false;
     return S_ISDIR(s.st_mode);
 }
 
-static int list_directory(const path_t& dirpath, std::vector<path_t>& imagepaths)
-{
+static int list_directory(const path_t &dirpath, std::vector<path_t> &imagepaths) {
     imagepaths.clear();
 
-    DIR* dir = opendir(dirpath.c_str());
-    if (!dir)
-    {
+    DIR *dir = opendir(dirpath.c_str());
+    if (!dir) {
         fprintf(stderr, "opendir failed %s\n", dirpath.c_str());
         return -1;
     }
 
-    struct dirent* ent = 0;
-    while ((ent = readdir(dir)))
-    {
+    struct dirent *ent = 0;
+    while ((ent = readdir(dir))) {
         if (ent->d_type != DT_REG)
             continue;
 
@@ -84,9 +85,10 @@ static int list_directory(const path_t& dirpath, std::vector<path_t>& imagepaths
     }
 
     closedir(dir);
+    std::sort(imagepaths.begin(), imagepaths.end());
 
     return 0;
 }
-#endif // _WIN32
 
+#endif // _WIN32
 #endif // FILESYSTEM_UTILS_H


### PR DESCRIPTION
On windows32, `opendir(dirpath.c_str());` will return the files in alphabetical ordering.

However, when built on gcc, `opendir(dirpath.c_str());` will not return the files in alphabetical order.

Unfortunately, dandere2x needs the files to be in alphabetical order to work. 

The change is really small and shouldn't affect overall performance.

Built and tested on Manjaro 18.04 and gcc 9.1.0