### PR TITLE
added sorting for file paths [formatting fixed]

### DIFF
--- a/src/filesystem_utils.h
+++ b/src/filesystem_utils.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <vector>
 #include <string>
+#include <algorithm>
 
 #if _WIN32
 #include <windows.h>
@@ -51,6 +52,7 @@ static int list_directory(const path_t& dirpath, std::vector<path_t>& imagepaths
     }
 
     _wclosedir(dir);
+    std::sort(imagepaths.begin(), imagepaths.end());
 
     return 0;
 }
@@ -84,6 +86,7 @@ static int list_directory(const path_t& dirpath, std::vector<path_t>& imagepaths
     }
 
     closedir(dir);
+    std::sort(imagepaths.begin(), imagepaths.end());
 
     return 0;
 }


### PR DESCRIPTION
On windows32, `opendir(dirpath.c_str());` will return the files in alphabetical ordering.

However, when built on gcc, `opendir(dirpath.c_str());` will not return the files in alphabetical order.

Unfortunately, dandere2x needs the files to be in alphabetical order to work. 

The change is really small and shouldn't affect overall performance.

Built and tested on Manjaro 18.04 and gcc 9.1.0

[fixed edit]

- Maintained coding style