### PR TITLE
update to match NCNNs changes to Pipeline::create

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(compile_shader SHADER_SRC)
     add_custom_command(
         OUTPUT ${SHADER_SPV_HEX_FILE}
         COMMAND ${GLSLANGVALIDATOR_EXECUTABLE}
-        ARGS -V -s -e ${SHADER_SRC_NAME_WE} --source-entrypoint main -x -o ${SHADER_SPV_HEX_FILE} ${SHADER_SRC_FULLPATH}
+        ARGS -V -s -x -o ${SHADER_SPV_HEX_FILE} ${SHADER_SRC_FULLPATH}
         DEPENDS ${SHADER_SRC_FULLPATH}
         COMMENT "Building SPIR-V module ${SHADER_SRC_NAME_WE}.spv"
         VERBATIM
@@ -33,7 +33,7 @@ macro(compile_shader SHADER_SRC)
     add_custom_command(
         OUTPUT ${SHADER_fp16s_SPV_HEX_FILE}
         COMMAND ${GLSLANGVALIDATOR_EXECUTABLE}
-        ARGS -DNCNN_fp16_storage=1 -V -s -e ${SHADER_fp16s_SRC_NAME_WE} --source-entrypoint main -x -o ${SHADER_fp16s_SPV_HEX_FILE} ${SHADER_SRC_FULLPATH}
+        ARGS -DNCNN_fp16_storage=1 -V -s -x -o ${SHADER_fp16s_SPV_HEX_FILE} ${SHADER_SRC_FULLPATH}
         DEPENDS ${SHADER_SRC_FULLPATH}
         COMMENT "Building SPIR-V module ${SHADER_fp16s_SRC_NAME_WE}.spv"
         VERBATIM
@@ -48,7 +48,7 @@ macro(compile_shader SHADER_SRC)
     add_custom_command(
         OUTPUT ${SHADER_int8s_SPV_HEX_FILE}
         COMMAND ${GLSLANGVALIDATOR_EXECUTABLE}
-        ARGS -DNCNN_fp16_storage=1 -DNCNN_int8_storage=1 -V -s -e ${SHADER_int8s_SRC_NAME_WE} --source-entrypoint main -x -o ${SHADER_int8s_SPV_HEX_FILE} ${SHADER_SRC_FULLPATH}
+        ARGS -DNCNN_fp16_storage=1 -DNCNN_int8_storage=1 -V -s -x -o ${SHADER_int8s_SPV_HEX_FILE} ${SHADER_SRC_FULLPATH}
         DEPENDS ${SHADER_SRC_FULLPATH}
         COMMENT "Building SPIR-V module ${SHADER_int8s_SRC_NAME_WE}.spv"
         VERBATIM

--- a/src/waifu2x.cpp
+++ b/src/waifu2x.cpp
@@ -120,34 +120,34 @@ int Waifu2x::load(const std::string& parampath, const std::string& modelpath)
         if (tta_mode)
         {
             if (net.opt.use_fp16_storage && net.opt.use_int8_storage)
-                waifu2x_preproc->create(waifu2x_preproc_tta_int8s_spv_data, sizeof(waifu2x_preproc_tta_int8s_spv_data), "waifu2x_preproc_tta_int8s", specializations, 9, 9);
+                waifu2x_preproc->create(waifu2x_preproc_tta_int8s_spv_data, sizeof(waifu2x_preproc_tta_int8s_spv_data), specializations);
             else if (net.opt.use_fp16_storage)
-                waifu2x_preproc->create(waifu2x_preproc_tta_fp16s_spv_data, sizeof(waifu2x_preproc_tta_fp16s_spv_data), "waifu2x_preproc_tta_fp16s", specializations, 9, 9);
+                waifu2x_preproc->create(waifu2x_preproc_tta_fp16s_spv_data, sizeof(waifu2x_preproc_tta_fp16s_spv_data), specializations);
             else
-                waifu2x_preproc->create(waifu2x_preproc_tta_spv_data, sizeof(waifu2x_preproc_tta_spv_data), "waifu2x_preproc_tta", specializations, 9, 9);
+                waifu2x_preproc->create(waifu2x_preproc_tta_spv_data, sizeof(waifu2x_preproc_tta_spv_data), specializations);
 
             if (net.opt.use_fp16_storage && net.opt.use_int8_storage)
-                waifu2x_postproc->create(waifu2x_postproc_tta_int8s_spv_data, sizeof(waifu2x_postproc_tta_int8s_spv_data), "waifu2x_postproc_tta_int8s", specializations, 9, 8);
+                waifu2x_postproc->create(waifu2x_postproc_tta_int8s_spv_data, sizeof(waifu2x_postproc_tta_int8s_spv_data), specializations);
             else if (net.opt.use_fp16_storage)
-                waifu2x_postproc->create(waifu2x_postproc_tta_fp16s_spv_data, sizeof(waifu2x_postproc_tta_fp16s_spv_data), "waifu2x_postproc_tta_fp16s", specializations, 9, 8);
+                waifu2x_postproc->create(waifu2x_postproc_tta_fp16s_spv_data, sizeof(waifu2x_postproc_tta_fp16s_spv_data), specializations);
             else
-                waifu2x_postproc->create(waifu2x_postproc_tta_spv_data, sizeof(waifu2x_postproc_tta_spv_data), "waifu2x_postproc_tta", specializations, 9, 8);
+                waifu2x_postproc->create(waifu2x_postproc_tta_spv_data, sizeof(waifu2x_postproc_tta_spv_data), specializations);
         }
         else
         {
             if (net.opt.use_fp16_storage && net.opt.use_int8_storage)
-                waifu2x_preproc->create(waifu2x_preproc_int8s_spv_data, sizeof(waifu2x_preproc_int8s_spv_data), "waifu2x_preproc_int8s", specializations, 2, 9);
+                waifu2x_preproc->create(waifu2x_preproc_int8s_spv_data, sizeof(waifu2x_preproc_int8s_spv_data), specializations);
             else if (net.opt.use_fp16_storage)
-                waifu2x_preproc->create(waifu2x_preproc_fp16s_spv_data, sizeof(waifu2x_preproc_fp16s_spv_data), "waifu2x_preproc_fp16s", specializations, 2, 9);
+                waifu2x_preproc->create(waifu2x_preproc_fp16s_spv_data, sizeof(waifu2x_preproc_fp16s_spv_data), specializations);
             else
-                waifu2x_preproc->create(waifu2x_preproc_spv_data, sizeof(waifu2x_preproc_spv_data), "waifu2x_preproc", specializations, 2, 9);
+                waifu2x_preproc->create(waifu2x_preproc_spv_data, sizeof(waifu2x_preproc_spv_data), specializations);
 
             if (net.opt.use_fp16_storage && net.opt.use_int8_storage)
-                waifu2x_postproc->create(waifu2x_postproc_int8s_spv_data, sizeof(waifu2x_postproc_int8s_spv_data), "waifu2x_postproc_int8s", specializations, 2, 8);
+                waifu2x_postproc->create(waifu2x_postproc_int8s_spv_data, sizeof(waifu2x_postproc_int8s_spv_data), specializations);
             else if (net.opt.use_fp16_storage)
-                waifu2x_postproc->create(waifu2x_postproc_fp16s_spv_data, sizeof(waifu2x_postproc_fp16s_spv_data), "waifu2x_postproc_fp16s", specializations, 2, 8);
+                waifu2x_postproc->create(waifu2x_postproc_fp16s_spv_data, sizeof(waifu2x_postproc_fp16s_spv_data), specializations);
             else
-                waifu2x_postproc->create(waifu2x_postproc_spv_data, sizeof(waifu2x_postproc_spv_data), "waifu2x_postproc", specializations, 2, 8);
+                waifu2x_postproc->create(waifu2x_postproc_spv_data, sizeof(waifu2x_postproc_spv_data), specializations);
         }
     }
 


### PR DESCRIPTION
With this commit: https://github.com/Tencent/ncnn/commit/1ea9de3bdf83079658f494e035180684b09ca0d6 ncnn changed the parameters to the Pipeline::create function causing waifu2x-ncnn-vulkan to fail to build.

I've updated the pipeline functions to match, but it now requires ncnn versions newer than that commit. Maybe there's some way to support old and new?