### PR TITLE
check for invalid option (denoise disabled, scale=1)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,7 +398,7 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    if (noise < -1 || noise > 3 || scale < 1 || scale > 2)
+    if (noise < -1 || noise > 3 || scale < 1 || scale > 2 || (noise == -1 && scale == 1))
     {
         fprintf(stderr, "invalid noise or scale argument\n");
         return -1;


### PR DESCRIPTION
This is equivalent to the original picture.

Fixes this:
![image](https://user-images.githubusercontent.com/37741639/80310936-f915e680-87d4-11ea-998d-171021120498.png)

Reported at: https://github.com/nihui/waifu2x-ncnn-vulkan/issues/59#issuecomment-618009728
