### PR TITLE
Fix double extension with directories

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -643,7 +643,7 @@ int main(int argc, char** argv)
                 // filename list is sorted, check if output image path conflicts
                 if (filename_noext == last_filename_noext)
                 {
-                    path_t output_filename2 = filename + PATHSTR('.') + format;
+                    path_t output_filename2 = filename_noext + PATHSTR('.') + format;
 #if _WIN32
                     fwprintf(stderr, L"both %ls and %ls output %ls ! %ls will output %ls\n", filename.c_str(), last_filename.c_str(), output_filename.c_str(), filename.c_str(), output_filename2.c_str());
 #else


### PR DESCRIPTION
when inputting a directory to waifu2x the output images would have 2 file extensions, for example "picture.png" -> "picture.png.png". On line 646 changing 

path_t output_filename2 = filename + PATHSTR('.') + format;

to

path_t output_filename2 = filename_noext + PATHSTR('.') + format;

fixes the glitch