### PR TITLE
Removed slow and unnecessary branching from compute shaders

### DIFF
--- a/src/waifu2x.cpp
+++ b/src/waifu2x.cpp
@@ -116,10 +116,10 @@ int Waifu2x::load(const std::string& parampath, const std::string& modelpath)
 #endif
 
         waifu2x_preproc = new ncnn::Pipeline(net.vulkan_device());
-        waifu2x_preproc->set_optimal_local_size_xyz(32, 32, 3);
+        waifu2x_preproc->set_optimal_local_size_xyz(32, 32, 1);
 
         waifu2x_postproc = new ncnn::Pipeline(net.vulkan_device());
-        waifu2x_postproc->set_optimal_local_size_xyz(32, 32, 3);
+        waifu2x_postproc->set_optimal_local_size_xyz(32, 32, 1);
 
         if (tta_mode)
         {

--- a/src/waifu2x_postproc.comp
+++ b/src/waifu2x_postproc.comp
@@ -73,11 +73,10 @@ void main()
     int v_offset = gy * p.outw + gx + p.offset_x;
 
     uint v32 = clamp(uint(floor(v)), 0, 255);
+    
+    int z = (bgr * (2 - gz % 3 + gz / 3)) + (1 - bgr) * gz;
 
-    if (bgr == 1 && gz != 3)
-        top_blob_data[v_offset * p.channels + 2 - gz] = uint8_t(v32);
-    else
-        top_blob_data[v_offset * p.channels + gz] = uint8_t(v32);
+    top_blob_data[v_offset * p.channels + z] = uint8_t(v32);
 #else
     int v_offset = gz * p.outcstep + gy * p.outw + gx + p.offset_x;
 

--- a/src/waifu2x_postproc_tta.comp
+++ b/src/waifu2x_postproc_tta.comp
@@ -91,11 +91,10 @@ void main()
     int v_offset = gy * p.outw + gx + p.offset_x;
 
     uint v32 = clamp(uint(floor(v)), 0, 255);
+    
+    int z = (bgr * (2 - gz % 3 + gz / 3)) + (1 - bgr) * gz;
 
-    if (bgr == 1 && gz != 3)
-        top_blob_data[v_offset * p.channels + 2 - gz] = uint8_t(v32);
-    else
-        top_blob_data[v_offset * p.channels + gz] = uint8_t(v32);
+    top_blob_data[v_offset * p.channels + z] = uint8_t(v32);
 #else
     int v_offset = gz * p.outcstep + gy * p.outw + gx + p.offset_x;
 

--- a/src/waifu2x_preproc.comp
+++ b/src/waifu2x_preproc.comp
@@ -62,12 +62,9 @@ void main()
 #if NCNN_int8_storage
     int v_offset = y * p.w + x;
 
-    float v;
+	int z = (bgr * (2 - gz % 3 + gz / 3)) + (1 - bgr) * gz;
 
-    if (bgr == 1 && gz != 3)
-        v = float(uint(bottom_blob_data[v_offset * p.channels + 2 - gz]));
-    else
-        v = float(uint(bottom_blob_data[v_offset * p.channels + gz]));
+	float v = float(uint(bottom_blob_data[v_offset * p.channels + z]));
 #else
     int v_offset = gz * p.cstep + y * p.w + x;
 

--- a/src/waifu2x_preproc_tta.comp
+++ b/src/waifu2x_preproc_tta.comp
@@ -69,12 +69,9 @@ void main()
 #if NCNN_int8_storage
     int v_offset = y * p.w + x;
 
-    float v;
+    int z = (bgr * (2 - gz % 3 + gz / 3)) + (1 - bgr) * gz;
 
-    if (bgr == 1 && gz != 3)
-        v = float(uint(bottom_blob_data[v_offset * p.channels + 2 - gz]));
-    else
-        v = float(uint(bottom_blob_data[v_offset * p.channels + gz]));
+    float v = float(uint(bottom_blob_data[v_offset * p.channels + z]));
 #else
     int v_offset = gz * p.cstep + y * p.w + x;
 


### PR DESCRIPTION
I removed the branch from the preprocessing and postprocessing compute shaders which were only for convenient indexing and replaced them by a one-liner to calculate the same index for both cases without branching.

This should improve performance by some percentages because code will perform better in parallel without branches.

I also changed the local_size from 32x32x3 to 32x32x1 because GPUs really tend to favor a power of 2 as local_size and the size should fit better to match different channel counts.