### PR TITLE
add video2x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ This package includes all the binaries and models required. It is portable, so n
 ### Example Command
 
 ```shell
+# image mode
 waifu2x-ncnn-vulkan.exe -i input.jpg -o output.png -n 2 -s 2
+
+# video mode
+waifu2x-ncnn-vulkan.exe -i input.mkv -o output.mkv -n 2 -s 2
 ```
 
 ### Full Usages
@@ -31,6 +35,8 @@ Usage: waifu2x-ncnn-vulkan -i infile -o outfile [options]...
   -v                   verbose output
   -i input-path        input image path (jpg/png/webp) or directory
   -o output-path       output image path (jpg/png/webp) or directory
+  -a video input       input video path
+  -b video output      output video path
   -n noise-level       denoise level (-1/0/1/2/3, default=0)
   -s scale             upscale ratio (1/2, default=2)
   -t tile-size         tile size (>=32/0=auto, default=0) can be 0,0,0 for multi-gpu
@@ -42,6 +48,8 @@ Usage: waifu2x-ncnn-vulkan -i infile -o outfile [options]...
 ```
 
 - `input-path` and `output-path` accept either file path or directory path
+- `video input` and `video output` accept video file path
+- if specified `input-path` and `output-path`, then `video input` and `video output` will be ignored
 - `noise-level` = noise level, large value means strong denoise effect, -1 = no effect
 - `scale` = scale level, 1 = no scaling, 2 = upscale 2x
 - `tile-size` = tile size, use smaller value to reduce GPU memory usage, default selects automatically

--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ This package includes all the binaries and models required. It is portable, so n
 waifu2x-ncnn-vulkan.exe -i input.jpg -o output.png -n 2 -s 2
 
 # video mode
-waifu2x-ncnn-vulkan.exe -i input.mkv -o output.mkv -n 2 -s 2
+waifu2x-ncnn-vulkan.exe -a input.mkv -b output.mkv -n 2 -s 2
 ```
 
 ### Full Usages
 
 ```console
 Usage: waifu2x-ncnn-vulkan -i infile -o outfile [options]...
+       waifu2x-ncnn-vulkan -a invideo -b outvideo [options]...
 
   -h                   show this help
   -v                   verbose output

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ option(USE_STATIC_MOLTENVK "link moltenvk static library" OFF)
 
 find_package(Threads)
 find_package(OpenMP)
+find_package(OpenCV REQUIRED)
 find_package(Vulkan REQUIRED)
 
 find_program(GLSLANGVALIDATOR_EXECUTABLE NAMES glslangValidator PATHS $ENV{VULKAN_SDK}/bin NO_CMAKE_FIND_ROOT_PATH)
@@ -67,6 +68,7 @@ macro(compile_shader SHADER_SRC)
 endmacro()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${OpenCV_INCLUDE_DIRS})
 
 if(OPENMP_FOUND)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -290,4 +292,4 @@ if(OPENMP_FOUND)
     list(APPEND WAIFU2X_LINK_LIBRARIES ${OpenMP_CXX_LIBRARIES})
 endif()
 
-target_link_libraries(waifu2x-ncnn-vulkan ${WAIFU2X_LINK_LIBRARIES})
+target_link_libraries(waifu2x-ncnn-vulkan ${WAIFU2X_LINK_LIBRARIES} opencv_core opencv_video opencv_videoio)


### PR DESCRIPTION
This is a pre-stage pull request. 

Currently, `waifu2x-ncnn-vulkan` depends on external utils like `FFmpeg` to extract each frame to a directory and then does the super-resolution operation on each image, which requires a potentially large amount of space to store all the frames.

This pr uses OpenCV (with `video` and `videoio` support) to read and write videos, avoiding using much disk space for saving each frame.

This can be designed as a feature that can be selected to be enabled by CMake option. Or `waifu2x-ncnn-vulkan` with video support can have a separate branch, as it will require OpenCV libraries and not everyone needs video support.

And there's one more issue, most of the processed frames are great, but some of them seem to be corrupted. For example,

![15](https://user-images.githubusercontent.com/5152503/101347231-a7acfa00-3881-11eb-960f-8f31408352a6.png)

Should I do a `memcpy` before passing the data to `cv::Mat`? [corresponding line](https://github.com/BlueCocoa/waifu2x-ncnn-vulkan/commit/368a1d94a708fa02649a10ffcab1eb6d7c2a2d72#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R476)