### PR TITLE
Fix double free in main.cpp's save

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,23 +387,6 @@ void* save(void* args)
         if (v.id == -233)
             break;
 
-        // free input pixel data
-        {
-            unsigned char* pixeldata = (unsigned char*)v.inimage.data;
-            if (v.webp == 1)
-            {
-                free(pixeldata);
-            }
-            else
-            {
-#if _WIN32
-                free(pixeldata);
-#else
-                stbi_image_free(pixeldata);
-#endif
-            }
-        }
-
         int success = 0;
 
         path_t ext = get_file_extension(v.outpath);


### PR DESCRIPTION
I should preface this by saying that **I do not know if this is the right solution**. This is probably hacky, as I do not know why a free was done there in the first place.

This is a follow-up to [this comment I made](https://github.com/nihui/waifu2x-ncnn-vulkan/issues/138#issuecomment-839254692) on #138.

This *should* fix #138 and fix #140.