### PR TITLE
Don't override CMAKE_BUILD_TYPE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,9 @@ project(waifu2x-ncnn-vulkan)
 
 cmake_minimum_required(VERSION 3.9)
 
-set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
 
 option(USE_SYSTEM_NCNN "build with system libncnn" OFF)
 option(USE_SYSTEM_WEBP "build with system libwebp" OFF)


### PR DESCRIPTION
This commit fixes CMake ignoring `CMAKE_BUILD_TYPE` passed to it.

Now the variable is set to `Release` only when empty (default).