### PR TITLE
fix cpu mode with tilesize smaller than image size

### DIFF
--- a/src/waifu2x.cpp
+++ b/src/waifu2x.cpp
@@ -594,7 +594,7 @@ int Waifu2x::process_cpu(const ncnn::Mat& inimage, ncnn::Mat& outimage) const
             int in_tile_x1 = std::min((xi + 1) * TILE_SIZE_X + prepadding_right, w);
 
             // crop tile
-            ncnn::Mat in;
+            ncnn::Mat in, in_nopad;
             {
                 if (channels == 3)
                 {
@@ -607,8 +607,10 @@ int Waifu2x::process_cpu(const ncnn::Mat& inimage, ncnn::Mat& outimage) const
                 if (channels == 4)
                 {
 #if _WIN32
+                    in_nopad = ncnn::Mat::from_pixels_roi(pixeldata, ncnn::Mat::PIXEL_BGRA2RGBA, w, h, xi * TILE_SIZE_X, yi * TILE_SIZE_Y, tile_w_nopad, tile_h_nopad);
                     in = ncnn::Mat::from_pixels_roi(pixeldata, ncnn::Mat::PIXEL_BGRA2RGBA, w, h, in_tile_x0, in_tile_y0, in_tile_x1 - in_tile_x0, in_tile_y1 - in_tile_y0);
 #else
+                    in_nopad = ncnn::Mat::from_pixels_roi(pixeldata, ncnn::Mat::PIXEL_RGBA, w, h, xi * TILE_SIZE_X, yi * TILE_SIZE_Y, tile_w_nopad, tile_h_nopad);
                     in = ncnn::Mat::from_pixels_roi(pixeldata, ncnn::Mat::PIXEL_RGBA, w, h, in_tile_x0, in_tile_y0, in_tile_x1 - in_tile_x0, in_tile_y1 - in_tile_y0);
 #endif
                 }
@@ -639,7 +641,7 @@ int Waifu2x::process_cpu(const ncnn::Mat& inimage, ncnn::Mat& outimage) const
 
                     if (channels == 4)
                     {
-                        in_alpha_tile = in.channel_range(3, 1).clone();
+                        in_alpha_tile = in_nopad.channel_range(3, 1).clone();
                     }
                 }
 
@@ -790,7 +792,7 @@ int Waifu2x::process_cpu(const ncnn::Mat& inimage, ncnn::Mat& outimage) const
 
                     if (channels == 4)
                     {
-                        in_alpha_tile = in.channel_range(3, 1).clone();
+                        in_alpha_tile = in_nopad.channel_range(3, 1).clone();
                     }
                 }
 


### PR DESCRIPTION
It was only tested on Linux platform. So, please check if it works on Windows. :)  fix #186

### The reason why it crashes
- In the original code, the Mat **out_alpha_tile** is generated from **in_alpha_tile**, and **in_alpha_tile** is extracted from Mat **in**. However, the destination for alpha channel copy is Mat **out**, which is a tile Mat without padding. At the same time, Mat **in** is already padded, which resulted in copying data more than output Mat can hold, which is a out of memory boundaries problem and explains why the refcount of **out** mat was overwritten.
- The tilesize of CPU mode used to be 4000, which is way larger than usual images, so that the code was working as intended. However, it was changed to 400 in a past commit, which turn a full image inference into a batch inference, and cause this bug.
