### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,7 @@ jobs:
         cmake --build . -j 2
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
macos-latest breaks the github workflow as is

I tried forking the repo and this was the first error I ran into: 

https://github.com/akai-katto/waifu2x-ncnn-vulkan/actions/runs/3449062092/jobs/5756656697

I changed the image used to macos-11 and it resolved the problem: 

https://github.com/akai-katto/waifu2x-ncnn-vulkan/actions/runs/3449131467/jobs/5756783924