### PR TITLE
fix MinGW compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,6 +246,10 @@ waifu2x_add_shader(waifu2x_postproc_tta.comp)
 
 add_custom_target(generate-spirv DEPENDS ${SHADER_SPV_HEX_FILES})
 
+if(MINGW)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -municode")
+endif()
+
 add_executable(waifu2x-ncnn-vulkan main.cpp waifu2x.cpp)
 
 add_dependencies(waifu2x-ncnn-vulkan generate-spirv)


### PR DESCRIPTION
Without the change, I can see the following error report:

```
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../lib/libmingw32.a(lib64_libmingw32_a-crt0_c.o): in function `main':
C:/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crt0_c.c:18: undefined reference to `WinMain'
collect2.exe: error: ld returned 1 exit status
mingw32-make[2]: *** [CMakeFiles\waifu2x-ncnn-vulkan.dir\build.make:133: waifu2x-ncnn-vulkan.exe] Error 1
mingw32-make[1]: *** [CMakeFiles\Makefile2:311: CMakeFiles/waifu2x-ncnn-vulkan.dir/all] Error 2
mingw32-make: *** [Makefile:148: all] Error 2
```

As far as I understand it, the problem is that MinGW expects main()/WinMain() without `-municode`, but the code uses wmain()/wWinMain().