### PR TITLE
build for manylinux

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,22 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+    - name: create-dummy-setup.py
+      run: |
+        cat << EOF > setup.py
+        from setuptools import setup, find_packages
+        from setuptools.dist import Distribution
+        class BinaryDistribution(Distribution):
+            def has_ext_modules(foo):
+                return True
+        setup(
+            name='waifu2x-ncnn-vulkan',
+            version='0.1',
+            packages=find_packages(),
+            distclass=BinaryDistribution
+        )
+        EOF
+
     - name: build
       uses: pypa/cibuildwheel@v3.1.1
       env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
             def has_ext_modules(foo):
                 return True
         setup(
-            name='waifu2x-ncnn-vulkan',
+            name='dummy',
             version='0.1',
             packages=find_packages(),
             distclass=BinaryDistribution
@@ -61,13 +61,14 @@ jobs:
         CIBW_BEFORE_ALL: cd /project/ &&
           mkdir build && cd build &&
           cmake ../src &&
-          cmake --build . -j $(nproc)
+          cmake --build . -j $(nproc) &&
+          mv waifu2x-ncnn-vulkan /host/tmp/
       with:
         output-dir: wheelhouse3
     - name: list
       run: |
         ls -l
-        ls -l build/
+        ls -l /tmp/
 
   macos:
     runs-on: macos-13

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
         cmake -A x64 ../src
         cmake --build . --config Release -j 4
 
-  ubuntu:
+  linux:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -56,8 +56,7 @@ jobs:
         CIBW_BEFORE_ALL: cd /project/ &&
           mkdir build && cd build &&
           cmake -DCMAKE_INSTALL_PREFIX=/host/tmp/install ../src &&
-          cmake --build . -j $(nproc) &&
-          cmake --build . --target install/strip
+          cmake --build . -j $(nproc)
       with:
         output-dir: wheelhouse3
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,12 +43,7 @@ jobs:
         class BinaryDistribution(Distribution):
             def has_ext_modules(foo):
                 return True
-        setup(
-            name='dummy',
-            version='0.1',
-            packages=find_packages(),
-            distclass=BinaryDistribution
-        )
+        setup(name='dummy', version='0.1', packages=find_packages(), distclass=BinaryDistribution)
         EOF
 
     - name: build
@@ -60,15 +55,11 @@ jobs:
         CIBW_REPAIR_WHEEL_COMMAND: ""
         CIBW_BEFORE_ALL: cd /project/ &&
           mkdir build && cd build &&
-          cmake ../src &&
+          cmake -DCMAKE_INSTALL_PREFIX=/host/tmp/install ../src &&
           cmake --build . -j $(nproc) &&
-          mv waifu2x-ncnn-vulkan /host/tmp/
+          cmake --build . --target install/strip
       with:
         output-dir: wheelhouse3
-    - name: list
-      run: |
-        ls -l
-        ls -l /tmp/
 
   macos:
     runs-on: macos-13

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,19 +52,22 @@ jobs:
         EOF
 
     - name: build
-      uses: pypa/cibuildwheel@v3.1.1
+      uses: pypa/cibuildwheel@v3.1.3
       env:
         CIBW_ARCHS_LINUX: "x86_64"
         CIBW_BUILD: 'cp310-manylinux_x86_64'
         CIBW_BUILD_VERBOSITY: 1
         CIBW_REPAIR_WHEEL_COMMAND: ""
-        CIBW_BEFORE_ALL: yum install gcc-toolset-11 -y &&
-          cd /project/ &&
+        CIBW_BEFORE_ALL: cd /project/ &&
           mkdir build && cd build &&
           cmake ../src &&
           cmake --build . -j $(nproc)
       with:
         output-dir: wheelhouse3
+    - name: list
+      run: |
+        ls -l
+        ls -l build/
 
   macos:
     runs-on: macos-13

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,10 +36,19 @@ jobs:
       with:
         submodules: 'recursive'
     - name: build
-      run: |
-        mkdir build && cd build
-        cmake ../src
-        cmake --build . -j 4
+      uses: pypa/cibuildwheel@v3.1.1
+      env:
+        CIBW_ARCHS_LINUX: "x86_64"
+        CIBW_BUILD: 'cp310-manylinux_x86_64'
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_REPAIR_WHEEL_COMMAND: ""
+        CIBW_BEFORE_ALL: yum install gcc-toolset-11 -y &&
+          cd /project/ &&
+          mkdir build && cd build &&
+          cmake ../src &&
+          cmake --build . -j $(nproc)
+      with:
+        output-dir: wheelhouse3
 
   macos:
     runs-on: macos-13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,43 @@ jobs:
 
   ubuntu:
     needs: [setup]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PACKAGENAME: ${{ needs.setup.outputs.APPNAME }}-${{ needs.setup.outputs.VERSION }}-ubuntu
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: build
+    - name: create-dummy-setup.py
       run: |
-        mkdir build && cd build
-        cmake ../src
-        cmake --build . -j 2
+        cat << EOF > setup.py
+        from setuptools import setup, find_packages
+        from setuptools.dist import Distribution
+        class BinaryDistribution(Distribution):
+            def has_ext_modules(foo):
+                return True
+        setup(
+            name='waifu2x-ncnn-vulkan',
+            version='0.1',
+            packages=find_packages(),
+            distclass=BinaryDistribution
+        )
+        EOF
+
+    - name: build
+      uses: pypa/cibuildwheel@v3.1.3
+      env:
+        CIBW_ARCHS_LINUX: "x86_64"
+        CIBW_BUILD: 'cp310-manylinux_x86_64'
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_REPAIR_WHEEL_COMMAND: ""
+        CIBW_BEFORE_ALL: cd /project/ &&
+          mkdir build && cd build &&
+          cmake ../src &&
+          cmake --build . -j $(nproc)
+      with:
+        output-dir: wheelhouse3
+
     - name: package
       run: |
         mkdir -p ${{ env.PACKAGENAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             def has_ext_modules(foo):
                 return True
         setup(
-            name='waifu2x-ncnn-vulkan',
+            name='dummy',
             version='0.1',
             packages=find_packages(),
             distclass=BinaryDistribution
@@ -59,7 +59,8 @@ jobs:
         CIBW_BEFORE_ALL: cd /project/ &&
           mkdir build && cd build &&
           cmake ../src &&
-          cmake --build . -j $(nproc)
+          cmake --build . -j $(nproc) &&
+          mv ${{ needs.setup.outputs.APPNAME }} /host/tmp/
       with:
         output-dir: wheelhouse3
 
@@ -67,7 +68,7 @@ jobs:
       run: |
         mkdir -p ${{ env.PACKAGENAME }}
         cp README.md LICENSE ${{ env.PACKAGENAME }}
-        cp build/${{ needs.setup.outputs.APPNAME }} ${{ env.PACKAGENAME }}
+        cp /tmp/${{ needs.setup.outputs.APPNAME }} ${{ env.PACKAGENAME }}
         strip -g ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
         cp -r models/* ${{ env.PACKAGENAME }}
         zip -9 -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
-on: workflow_dispatch
+# on: workflow_dispatch
+on:
+  pull_request:
+    branches: [master]
 
 env:
   VULKANSDK_VERSION: 1.4.309.0
@@ -41,12 +44,7 @@ jobs:
         class BinaryDistribution(Distribution):
             def has_ext_modules(foo):
                 return True
-        setup(
-            name='dummy',
-            version='0.1',
-            packages=find_packages(),
-            distclass=BinaryDistribution
-        )
+        setup(name='dummy', version='0.1', packages=find_packages(), distclass=BinaryDistribution)
         EOF
 
     - name: build
@@ -58,9 +56,9 @@ jobs:
         CIBW_REPAIR_WHEEL_COMMAND: ""
         CIBW_BEFORE_ALL: cd /project/ &&
           mkdir build && cd build &&
-          cmake ../src &&
+          cmake -DCMAKE_INSTALL_PREFIX=/host/tmp/install ../src &&
           cmake --build . -j $(nproc) &&
-          mv ${{ needs.setup.outputs.APPNAME }} /host/tmp/
+          cmake --build . --target install/strip
       with:
         output-dir: wheelhouse3
 
@@ -68,7 +66,7 @@ jobs:
       run: |
         mkdir -p ${{ env.PACKAGENAME }}
         cp README.md LICENSE ${{ env.PACKAGENAME }}
-        cp /tmp/${{ needs.setup.outputs.APPNAME }} ${{ env.PACKAGENAME }}
+        cp /tmp/install/bin/${{ needs.setup.outputs.APPNAME }} ${{ env.PACKAGENAME }}
         strip -g ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
         cp -r models/* ${{ env.PACKAGENAME }}
         zip -9 -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}
@@ -157,18 +155,19 @@ jobs:
       run: |
         export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-x86_64 && cd build-x86_64
-        cmake -DUSE_STATIC_MOLTENVK=ON -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+        cmake -DCMAKE_INSTALL_PREFIX=install -DUSE_STATIC_MOLTENVK=ON -DCMAKE_OSX_ARCHITECTURES="x86_64" \
             -DOpenMP_C_FLAGS="-Xclang -fopenmp" -DOpenMP_CXX_FLAGS="-Xclang -fopenmp" \
             -DOpenMP_C_LIB_NAMES="libomp" -DOpenMP_CXX_LIB_NAMES="libomp" \
             -DOpenMP_libomp_LIBRARY="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libomp.a" \
             -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
             ../src
         cmake --build . -j 4
+        cmake --build . --target install/strip
     - name: build-arm64
       run: |
         export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-arm64 && cd build-arm64
-        cmake -DUSE_STATIC_MOLTENVK=ON -DCMAKE_OSX_ARCHITECTURES="arm64" \
+        cmake -DCMAKE_INSTALL_PREFIX=install -DUSE_STATIC_MOLTENVK=ON -DCMAKE_OSX_ARCHITECTURES="arm64" \
             -DCMAKE_CROSSCOMPILING=ON -DCMAKE_SYSTEM_PROCESSOR=arm64 \
             -DOpenMP_C_FLAGS="-Xclang -fopenmp" -DOpenMP_CXX_FLAGS="-Xclang -fopenmp" \
             -DOpenMP_C_LIB_NAMES="libomp" -DOpenMP_CXX_LIB_NAMES="libomp" \
@@ -176,11 +175,12 @@ jobs:
             -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
             ../src
         cmake --build . -j 4
+        cmake --build . --target install/strip
     - name: package
       run: |
         mkdir -p ${{ env.PACKAGENAME }}
         cp README.md LICENSE ${{ env.PACKAGENAME }}
-        lipo -create build-x86_64/${{ needs.setup.outputs.APPNAME }} build-arm64/${{ needs.setup.outputs.APPNAME }} -o ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
+        lipo -create build-x86_64/install/${{ needs.setup.outputs.APPNAME }} build-arm64/install/${{ needs.setup.outputs.APPNAME }} -o ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
         strip ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
         cp -r models/* ${{ env.PACKAGENAME }}
         zip -9 -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}
@@ -202,14 +202,15 @@ jobs:
     - name: build
       run: |
         mkdir build; cd build
-        cmake -A x64 ../src
+        cmake -A x64 -DCMAKE_INSTALL_PREFIX=install ../src
         cmake --build . --config Release -j 4
+        cmake --build . --config Release --target install
     - name: package
       run: |
         mkdir ${{ env.PACKAGENAME }}
         Copy-Item -Verbose -Path "README.md" -Destination "${{ env.PACKAGENAME }}"
         Copy-Item -Verbose -Path "LICENSE" -Destination "${{ env.PACKAGENAME }}"
-        Copy-Item -Verbose -Path "build\Release\${{ needs.setup.outputs.APPNAME }}.exe" -Destination "${{ env.PACKAGENAME }}"
+        Copy-Item -Verbose -Path "build\install\bin\${{ needs.setup.outputs.APPNAME }}.exe" -Destination "${{ env.PACKAGENAME }}"
         Copy-Item -Verbose -Path "C:\windows\system32\vcomp140.dll" -Destination "${{ env.PACKAGENAME }}"
         Copy-Item -Verbose -Recurse -Path "models\*" -Destination "${{ env.PACKAGENAME }}"
         7z a -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}
@@ -219,19 +220,19 @@ jobs:
         name: ${{ env.PACKAGENAME }}
         path: ${{ env.PACKAGENAME }}.zip
 
-  release:
-    needs: [setup, ubuntu, macos, windows]
-    runs-on: ubuntu-latest
-    steps:
-    - name: download
-      uses: actions/download-artifact@v4
-      with:
-        path: artifacts
-
-    - name: create-release
-      uses: softprops/action-gh-release@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        tag_name: ${{ needs.setup.outputs.VERSION }}
-        name: Release ${{ needs.setup.outputs.VERSION }}
-        files: artifacts/*/*.zip
+  # release:
+  #   needs: [setup, ubuntu, macos, windows]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: download
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       path: artifacts
+  #
+  #   - name: create-release
+  #     uses: softprops/action-gh-release@v2
+  #     with:
+  #       token: ${{ secrets.GITHUB_TOKEN }}
+  #       tag_name: ${{ needs.setup.outputs.VERSION }}
+  #       name: Release ${{ needs.setup.outputs.VERSION }}
+  #       files: artifacts/*/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
         DATE=`date +'%Y%m%d'`
         echo "VERSION=${DATE}" >> $GITHUB_OUTPUT
 
-  ubuntu:
+  linux:
     needs: [setup]
     runs-on: ubuntu-latest
     env:
-      PACKAGENAME: ${{ needs.setup.outputs.APPNAME }}-${{ needs.setup.outputs.VERSION }}-ubuntu
+      PACKAGENAME: ${{ needs.setup.outputs.APPNAME }}-${{ needs.setup.outputs.VERSION }}-linux
     steps:
     - uses: actions/checkout@v4
       with:
@@ -180,7 +180,7 @@ jobs:
       run: |
         mkdir -p ${{ env.PACKAGENAME }}
         cp README.md LICENSE ${{ env.PACKAGENAME }}
-        lipo -create build-x86_64/install/${{ needs.setup.outputs.APPNAME }} build-arm64/install/${{ needs.setup.outputs.APPNAME }} -o ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
+        lipo -create build-x86_64/install/bin/${{ needs.setup.outputs.APPNAME }} build-arm64/install/bin/${{ needs.setup.outputs.APPNAME }} -o ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
         strip ${{ env.PACKAGENAME }}/${{ needs.setup.outputs.APPNAME }}
         cp -r models/* ${{ env.PACKAGENAME }}
         zip -9 -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}
@@ -221,7 +221,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   # release:
-  #   needs: [setup, ubuntu, macos, windows]
+  #   needs: [setup, linux, macos, windows]
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release
-# on: workflow_dispatch
-on:
-  pull_request:
-    branches: [master]
+on: workflow_dispatch
+# on:
+#   pull_request:
+#     branches: [master]
 
 env:
   VULKANSDK_VERSION: 1.4.309.0
@@ -220,19 +220,19 @@ jobs:
         name: ${{ env.PACKAGENAME }}
         path: ${{ env.PACKAGENAME }}.zip
 
-  # release:
-  #   needs: [setup, linux, macos, windows]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: download
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       path: artifacts
-  #
-  #   - name: create-release
-  #     uses: softprops/action-gh-release@v2
-  #     with:
-  #       token: ${{ secrets.GITHUB_TOKEN }}
-  #       tag_name: ${{ needs.setup.outputs.VERSION }}
-  #       name: Release ${{ needs.setup.outputs.VERSION }}
-  #       files: artifacts/*/*.zip
+  release:
+    needs: [setup, linux, macos, windows]
+    runs-on: ubuntu-latest
+    steps:
+    - name: download
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+
+    - name: create-release
+      uses: softprops/action-gh-release@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: ${{ needs.setup.outputs.VERSION }}
+        name: Release ${{ needs.setup.outputs.VERSION }}
+        files: artifacts/*/*.zip

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,3 +93,6 @@ if(USE_STATIC_MOLTENVK)
 endif()
 
 target_link_libraries(waifu2x-ncnn-vulkan ${WAIFU2X_LINK_LIBRARIES})
+
+include(GNUInstallDirs)
+install(TARGETS waifu2x-ncnn-vulkan RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
manylinux_2_28 (AlmaLinux 8 based)

expected to be compatible with other distros using glibc 2.28 or later, including:

- Debian 10+
- Ubuntu 18.10+
- Fedora 29+
- CentOS/RHEL 8+
