### PR TITLE
Only check if the input and output are a directory once

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -663,7 +663,8 @@ int main(int argc, char** argv)
                 input_files[i] = inputpath + PATHSTR('/') + filename;
                 output_files[i] = outputpath + PATHSTR('/') + output_filename;
             }
-        } else if (!input_is_directory && !output_is_directory)
+        }
+        else if (!input_is_directory && !output_is_directory)
         {
             input_files.push_back(inputpath);
             output_files.push_back(outputpath);


### PR DESCRIPTION
This is minor, but it saves a few unnecessary stat() calls.